### PR TITLE
Add compatibility and update attribute in .nuspec

### DIFF
--- a/Base3264-UrlEncoder.Tests/Base3264-UrlEncoder.Tests.csproj
+++ b/Base3264-UrlEncoder.Tests/Base3264-UrlEncoder.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1;netstandard2.0;net451</TargetFrameworks>
     <RootNamespace>Base3264_UrlEncoder.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/Base3264-UrlEncoder/Base3264-UrlEncoder.csproj
+++ b/Base3264-UrlEncoder/Base3264-UrlEncoder.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.1;netstandard2.0;net451</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.CommandLine" Version="5.10.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/Base3264-UrlEncoder/Base3264-UrlEncoder.nuspec
+++ b/Base3264-UrlEncoder/Base3264-UrlEncoder.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Base3264-UrlEncoder</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <title>Base3264-UrlEncoder</title>
     <authors>Eric Lau, Mhano Harkness</authors>
     <owners>ericlau-solid, mhano</owners>
-    <licenseUrl>https://www.codeproject.com/info/cpol10.aspx</licenseUrl>
+    <license type="file">LICENSE.md</license>
     <projectUrl>https://github.com/ericlau-solid/Base3264-UrlEncoder/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>Support for crockford base32 encoding</releaseNotes>

--- a/Base3264-UrlEncoder/Base3264-UrlEncoder.nuspec
+++ b/Base3264-UrlEncoder/Base3264-UrlEncoder.nuspec
@@ -22,4 +22,12 @@ Base64Url is more compact than Base32Url and it is almost always usable as a URL
     <copyright>Copyright Mhano Harkness and Eric Lau 2014-2017</copyright>
     <tags>base32 zbase32 z-base-32 base64url base64 crockford profanity Base3264Encoding Base32Url rfc4648</tags>
   </metadata>
+
+  <files>
+    <file src="..\LICENSE.md" target="" />
+    <file src="bin\Release\net5.0\Base3264-UrlEncoder.dll" target="lib\net5.0\Base3264-UrlEncoder.dll" />
+    <file src="bin\Release\net451\Base3264-UrlEncoder.dll" target="lib\net451\Base3264-UrlEncoder.dll" />
+    <file src="bin\Release\netcoreapp2.1\Base3264-UrlEncoder.dll" target="lib\netcoreapp2.1\Base3264-UrlEncoder.dll" />
+    <file src="bin\Release\netstandard2.0\Base3264-UrlEncoder.dll" target="lib\netstandard2.0\Base3264-UrlEncoder.dll" />
+  </files>
 </package>


### PR DESCRIPTION
- Add compatibility with .NET Core 2.1, .NET 5

- replace deprecated attribute 'licenseUrl' with 'license' in .nuspec